### PR TITLE
WIP: fix checksum error in bmap files and unpacked images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] Q1 2024
+- fixed error where bmap files would not match to images after omnect-cli operations.
+
 ## [0.17.1] Q4 2023
 - added some useful error messages
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.17.1"
+version = "0.17.2"
 
 [dependencies]
 actix-web = "4.4"

--- a/src/file/compression.rs
+++ b/src/file/compression.rs
@@ -120,15 +120,19 @@ impl Compression {
 }
 
 pub fn decompress(image_file_name: &PathBuf, compression: &Compression) -> Result<PathBuf> {
-    let mut new_image_file = image_file_name.to_str().unwrap();
-    if let Some(p) = new_image_file.strip_suffix(compression.extension()) {
-        new_image_file = p;
+    let mut new_image_file = PathBuf::from(image_file_name);
+
+    if let Some(extension) = new_image_file.extension() {
+        if extension == compression.extension() {
+            new_image_file.set_extension("");
+        }
     }
-    let mut destination = File::create(new_image_file)?;
+
+    let mut destination = File::create(&new_image_file)?;
     let mut source = File::open(image_file_name)?;
     let bytes_written = compression.decompress(&mut source, &mut destination)?;
     debug!("image::decompress: copied {} bytes.", bytes_written);
-    Ok(PathBuf::from(new_image_file))
+    Ok(new_image_file)
 }
 
 pub fn compress(image_file_name: &PathBuf, compression: &Compression) -> Result<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::process;
 
 fn main() {
     if cfg!(debug_assertions) {
-        Builder::from_env(Env::default().default_filter_or("debug,bollard::read=info")).init();
+        Builder::from_env(Env::default().default_filter_or("debug")).init();
     } else {
         Builder::from_env(Env::default().default_filter_or("info")).init();
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,7 @@ const TMPDIR_FORMAT_STR: &str = "/tmp/omnect-cli-integration-tests/";
 
 lazy_static! {
     static ref LOG: () = if cfg!(debug_assertions) {
-        Builder::from_env(Env::default().default_filter_or("debug,bollard::read=info")).init()
+        Builder::from_env(Env::default().default_filter_or("debug")).init()
     } else {
         Builder::from_env(Env::default().default_filter_or("info")).init()
     };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -684,6 +684,24 @@ fn check_image_decompression() {
         .arg(&image_path)
         .assert();
     assert.success();
+
+    let mut unpacked_image_path = PathBuf::from(image_path);
+    unpacked_image_path.set_extension("");
+
+    assert!(unpacked_image_path.try_exists().is_ok_and(|exists| exists));
+
+    // use bmaptool to verify that the checksum of the bmap file and the image
+    // still match after the copy operations
+    let mut copy_path = tr.pathbuf();
+    copy_path.push("image_copy.wic");
+
+    let assert = Command::new("bmaptool")
+        .arg("copy")
+        .arg(&unpacked_image_path)
+        .arg(&copy_path)
+        .assert();
+
+    assert.success();
 }
 
 #[tokio::test]


### PR DESCRIPTION
The unpacked image name would erroneously include a trailing dot, resulting in the bmap having the wrong file name. This would cause the cli to create a new bmap file instead of updating it, thus leading to discrepancies between bmap file and image.