### PR TITLE
refactored temporary image handling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] Q1 2024
+- refactored temporary image handling: use .tmp in current working directory instead of /tmp/uuid/ 
+
 ## [0.17.1] Q4 2023
 - added some useful error messages
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.17.1"
+version = "0.17.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2198,6 +2198,7 @@ dependencies = [
  "open",
  "regex",
  "reqwest",
+ "scopeguard",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2207,7 +2208,6 @@ dependencies = [
  "tokio",
  "toml",
  "url",
- "uuid",
  "validator",
  "xz2",
 ]
@@ -3439,15 +3439,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "validator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.17.1"
+version = "0.17.3"
 
 [dependencies]
 actix-web = "4.4"
@@ -27,6 +27,7 @@ oauth2 = "4.4"
 open = "4.1"
 regex = "1.5.5"
 reqwest = { version = "0.11", features = ["json"] }
+scopeguard = "1.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_path_to_error = "0.1"
@@ -41,7 +42,6 @@ tokio = { version = "1", features = [
     "net",
 ] }
 toml = "0.5"
-uuid = { version = "0.8", default-features = false, features = ["v4"] }
 url = "2.4"
 validator = { version = "0.14", features = ["derive"] }
 xz2 = "0.1"

--- a/src/file/functions.rs
+++ b/src/file/functions.rs
@@ -223,7 +223,7 @@ pub fn copy_to_image(
     generate_bmap: bool,
 ) -> Result<()> {
     // we use the folder the image is located in
-    // the caller is responsible to create a /tmp/ directory if needed
+    // the caller is responsible to possibly create a temporary directory if needed
     let working_dir = image_file
         .parent()
         .context("copy_to_image: cannot get directory of image")?
@@ -311,7 +311,7 @@ pub fn copy_to_image(
 
 pub fn copy_from_image(file_copy_params: &[FileCopyFromParams], image_file: &Path) -> Result<()> {
     // we use the folder the image is located in
-    // the caller is responsible to create a /tmp/ directory if needed
+    // the caller is responsible to possibly create a temporary directory if needed
     let working_dir = image_file
         .parent()
         .context("copy_to_image: cannot get directory of image")?

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -514,6 +514,8 @@ fn check_file_copy_ext4() {
 }
 
 fn check_file_copy(tr: Testrunner, partition: &str) {
+    let mut tmp_path = std::env::current_dir().unwrap();
+    tmp_path.push(".tmp");
     let in_file1 = tr.to_pathbuf("testfiles/boot.scr");
     let in_file1 = in_file1.to_str().unwrap();
     let in_file2 = tr.to_pathbuf("testfiles/dps-payload.json");
@@ -541,6 +543,8 @@ fn check_file_copy(tr: Testrunner, partition: &str) {
         .arg(&image_path)
         .assert();
     assert.success();
+
+    assert!(!tmp_path.try_exists().is_ok_and(|exists| exists));
 
     let mut copy_from_img = Command::cargo_bin("omnect-cli").unwrap();
     let assert = copy_from_img


### PR DESCRIPTION
use .tmp directory in current working directory instead of /tmp/uuid/