### PR TITLE
Add fix to establish ssh tunnels to dev and prod devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added ability to specify authentication provider and environment with
   configuration files (default to prod environment)
 - removed bollard logging setup
+- changed default compression rate to 4
 - bumped version of toml crate
 - fixed error where bmap files would not match to images after omnect-cli operations
+- integration tests:
+  - check if image is changed or unchanged after a command was run
+  - check generated bmap file
 
 ## [0.17.1] Q4 2023
 - added some useful error messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.17.2] Q1 2024
-- fixed error where bmap files would not match to images after omnect-cli operations.
+## [0.18.0] Q1 2024
+- added ability to specify authentication provider and environment with
+  configuration files (default to prod environment)
+- removed bollard logging setup
+- bumped version of toml crate
+- fixed error where bmap files would not match to images after omnect-cli operations
 
 ## [0.17.1] Q4 2023
 - added some useful error messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] Q1 2024
+- fixed error where bmap files would not match to images after omnect-cli operations.
+
 ## [0.17.1] Q4 2023
 - added some useful error messages
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -178,7 +178,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -578,7 +578,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -867,7 +867,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1348,7 +1348,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2269,7 +2269,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2389,7 +2389,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2504,7 +2504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2533,18 +2533,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2851,22 +2851,22 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2908,7 +2908,16 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3065,7 +3074,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3087,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3173,7 +3182,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3256,7 +3265,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3295,11 +3304,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -3307,6 +3319,9 @@ name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3315,6 +3330,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -3345,7 +3373,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3561,7 +3589,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3595,7 +3623,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3915,7 +3943,7 @@ checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1", features = [
     "fs",
     "net",
 ] }
-toml = "0.5"
+toml = "0.8"
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
 url = { version = "2.4", feature = ["serde"] }
 validator = { version = "0.14", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.17.2"
+version = "0.18.0"
 
 [dependencies]
 actix-web = "4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ oauth2 = "4.4"
 open = "4.1"
 regex = "1.5.5"
 reqwest = { version = "0.11", features = ["json"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_path_to_error = "0.1"
 stdext = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.17.1"
+version = "0.17.2"
 
 [dependencies]
 actix-web = "4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1", features = [
 ] }
 toml = "0.5"
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
-url = "2.4"
+url = { version = "2.4", feature = ["serde"] }
 validator = { version = "0.14", features = ["derive"] }
 xz2 = "0.1"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ omnect-cli is a command-line tool to manage omnect-os empowered devices. It prov
 - Generic configuration of services
   - copy files to image in order to configure e.g. boot service, firewall, wifi and others
   - copy files from image, e.g. to patch and re-inject configurations
-- ssh: 
+- ssh:
   - inject a ssh root ca and device principal for ssh tunnel creation
 
 Further omnect-cli supports device management features. Currently supported:
@@ -138,7 +138,6 @@ Options:
   -d <dir> optional: directory where the ssh key pair, certificate, and configuration are stored to
   -k <key> optional: path to an existing private ssh key to use for the connection. Requires the existence of the public key <key>.pub
   -c <config_path> optional: path where the ssh configuration should be stored to
-  -b <backend address> optional: address of omnect cloud service, defaults to https://cp.omnect.conplement.cloud
   --dev mandatory: use development authentication service, mutually excusive with `--prod`
   --prod mandatory: use production authentication service, mutually excusive with `--dev`
 ```

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Options:
 
 One can use `omnect-cli` to create a tunneled ssh connection to a device in the field. This is especially useful if the device is behind a NAT and can not directly be contacted. The device must have the `ssh` activated for this. Per default, this command will create a single use ssh key pair, certificate, and ssh configuration to establish a connection to the device.
 
+To create an ssh tunnel, `omnect-cli` must first authenticate against the authentication service. The service credentials vary, depending on whether the device is in the `dev` or `prod` environment.
+
 **Note**: if unused, the tunnel will close after 5 minutes.
 
 Creating the ssh tunnel:
@@ -137,13 +139,15 @@ Options:
   -k <key> optional: path to an existing private ssh key to use for the connection. Requires the existence of the public key <key>.pub
   -c <config_path> optional: path where the ssh configuration should be stored to
   -b <backend address> optional: address of omnect cloud service, defaults to https://cp.omnect.conplement.cloud
+  --dev mandatory: use development authentication service, mutually excusive with `--prod`
+  --prod mandatory: use production authentication service, mutually excusive with `--dev`
 ```
 
 #### Example usage
 
-Open an ssh tunnel to the device `test_device` as follows:
+Open an ssh tunnel to the device `test_device` in the `dev` environment as follows:
 ```sh
-~ omnect-cli ssh set-connection test_device
+~ omnect-cli ssh set-connection test_device --dev
 
 Successfully established ssh tunnel!
 Certificate dir: /run/user/1000/omnect-cli

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Options:
 
 One can use `omnect-cli` to create a tunneled ssh connection to a device in the field. This is especially useful if the device is behind a NAT and can not directly be contacted. The device must have the `ssh` activated for this. Per default, this command will create a single use ssh key pair, certificate, and ssh configuration to establish a connection to the device.
 
-To create an ssh tunnel, `omnect-cli` must first authenticate against the authentication service. The service credentials vary, depending on whether the device is in the `dev` or `prod` environment.
+To create an ssh tunnel, `omnect-cli` must first authenticate against the authentication service. The service credentials vary, depending on the omnect cloud environment. They default to omnect-prod.
 
 **Note**: if unused, the tunnel will close after 5 minutes.
 

--- a/README.md
+++ b/README.md
@@ -138,28 +138,50 @@ Options:
   -d <dir> optional: directory where the ssh key pair, certificate, and configuration are stored to
   -k <key> optional: path to an existing private ssh key to use for the connection. Requires the existence of the public key <key>.pub
   -c <config_path> optional: path where the ssh configuration should be stored to
-  --dev mandatory: use development authentication service, mutually excusive with `--prod`
-  --prod mandatory: use production authentication service, mutually excusive with `--dev`
+  --env <env_config_path> optional: path to a .toml configuration specifying the devices execution environment, defaults to the production environment.
 ```
 
 #### Example usage
 
-Open an ssh tunnel to the device `test_device` in the `dev` environment as follows:
+Open an ssh tunnel to the device `prod_device` in the `prod` environment as follows:
 ```sh
-~ omnect-cli ssh set-connection test_device --dev
+~ omnect-cli ssh set-connection prod_device
 
 Successfully established ssh tunnel!
 Certificate dir: /run/user/1000/omnect-cli
 Configuration path: /run/user/1000/omnect-cli/ssh_config
 Use the configuration in "/run/user/1000/omnect-cli/ssh_config" to use the tunnel, e.g.:
-ssh -F /run/user/1000/omnect-cli/ssh_config test_device
+ssh -F /run/user/1000/omnect-cli/ssh_config prod_device
 ```
 Now follow the command output to establish a connection to the device as such:
 
 ```sh
-~ ssh -F /run/user/1000/omnect-cli/ssh_config test_device
+~ ssh -F /run/user/1000/omnect-cli/ssh_config prod_device
 
-[omnect@test_device ~]$
+[omnect@prod_device ~]$
+```
+
+To connect to the device `dev_device` in the `dev` environment, we additionally
+have to supply a configuration with backend and the authentication details for
+the `dev` environment:
+
+```dev_env.toml
+backend = 'https://cp.dev.omnect.conplement.cloud'
+
+[auth.Keycloak]
+provider = 'https://keycloak.omnect.conplement.cloud'
+realm = 'cp-dev'
+client_id = 'cp-development'
+bind_addr = 'localhost:4000'
+redirect = 'http://localhost:4000'
+```
+
+You then have to pass this configuration with the `--env` flag:
+```sh
+~ omnect-cli ssh set-connection dev_device --env dev_env.toml
+
+Successfully established ssh tunnel!
+...
 ```
 
 # Troubleshooting

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -260,4 +260,11 @@ lazy_static! {
         "localhost:4000",
         "http://localhost:4000",
     );
+    pub static ref AUTH_INFO_PROD: KeycloakInfo = KeycloakInfo::new(
+        "https://keycloak.omnect.conplement.cloud",
+        "cp-prod",
+        "cp-production",
+        "localhost:4000",
+        "http://localhost:4000",
+    );
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use crate::file::{
     compression::Compression,
     functions::{FileCopyFromParams, FileCopyToParams},
 };
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 
 const COPYRIGHT: &str = "Copyright © 2021 by conplement AG";
 
@@ -173,6 +173,11 @@ pub enum SshConfig {
     },
 
     /// set ssh connection parameters
+    #[clap(group(
+        ArgGroup::new("environment")
+            .required(true)
+            .args(&["prod", "dev"])
+    ))]
     SetConnection {
         /// username for the login on the device.
         #[arg(short = 'u', long = "user", default_value = "omnect")]
@@ -201,6 +206,12 @@ pub enum SshConfig {
         backend: String,
         /// name of the device for which the ssh tunnel should be created.
         device: String,
+        /// connect to production environment
+        #[clap(long, group = "environment", action)]
+        prod: bool,
+        /// connect to dev environment
+        #[clap(long, group = "environment", action)]
+        dev: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use crate::file::{
     compression::Compression,
     functions::{FileCopyFromParams, FileCopyToParams},
 };
-use clap::{ArgGroup, Parser};
+use clap::Parser;
 
 const COPYRIGHT: &str = "Copyright © 2021 by conplement AG";
 
@@ -173,11 +173,6 @@ pub enum SshConfig {
     },
 
     /// set ssh connection parameters
-    #[clap(group(
-        ArgGroup::new("environment")
-            .required(true)
-            .args(&["prod", "dev"])
-    ))]
     SetConnection {
         /// username for the login on the device.
         #[arg(short = 'u', long = "user", default_value = "omnect")]
@@ -199,12 +194,9 @@ pub enum SshConfig {
         config_path: Option<std::path::PathBuf>,
         /// name of the device for which the ssh tunnel should be created.
         device: String,
-        /// connect to production environment
-        #[clap(long, group = "environment", action)]
-        prod: bool,
-        /// connect to dev environment
-        #[clap(long, group = "environment", action)]
-        dev: bool,
+        /// path to a configuration file with parameters for the backend
+        /// environment.
+        env: Option<std::path::PathBuf>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,11 +192,12 @@ pub enum SshConfig {
         /// Linux).
         #[arg(short = 'c', long = "config-path")]
         config_path: Option<std::path::PathBuf>,
+        /// path to a .toml configuration specifying the devices execution
+        /// environment, defaults to the production environment.
+        #[arg(short = 'e', long = "env")]
+        env: Option<std::path::PathBuf>,
         /// name of the device for which the ssh tunnel should be created.
         device: String,
-        /// path to a configuration file with parameters for the backend
-        /// environment.
-        env: Option<std::path::PathBuf>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -197,13 +197,6 @@ pub enum SshConfig {
         /// Linux).
         #[arg(short = 'c', long = "config-path")]
         config_path: Option<std::path::PathBuf>,
-        /// address of the backend API
-        #[arg(
-            short = 'b',
-            long = "backend",
-            default_value = "https://cp.omnect.conplement.cloud"
-        )]
-        backend: String,
         /// name of the device for which the ssh tunnel should be created.
         device: String,
         /// connect to production environment

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ impl From<AuthProvider> for AuthInfo {
 #[derive(Deserialize)]
 pub struct BackendConfig {
     pub backend: url::Url,
-    pub auth_provider: AuthProvider,
+    pub auth: AuthProvider,
 }
 
 lazy_static::lazy_static! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,68 @@
+use serde::Deserialize;
+
+use crate::auth::AuthInfo;
+
+#[derive(Clone, Deserialize)]
+pub struct KeycloakInfo {
+    provider: String,
+    realm: String,
+    client_id: String,
+    bind_addr: String,
+    redirect: url::Url,
+}
+
+impl From<KeycloakInfo> for AuthInfo {
+    fn from(val: KeycloakInfo) -> Self {
+        AuthInfo {
+            auth_url: format!(
+                "{}/realms/{}/protocol/openid-connect/auth",
+                val.provider, val.realm
+            ),
+            token_url: format!(
+                "{}/realms/{}/protocol/openid-connect/token",
+                val.provider, val.realm
+            ),
+            bind_addr: val.bind_addr,
+            redirect_addr: val.redirect,
+            client_id: val.client_id,
+        }
+    }
+}
+
+#[derive(Clone, Deserialize)]
+pub enum AuthProvider {
+    Keycloak(KeycloakInfo),
+}
+
+impl From<AuthProvider> for AuthInfo {
+    fn from(val: AuthProvider) -> Self {
+        match val {
+            AuthProvider::Keycloak(kc) => kc.into(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct BackendConfig {
+    pub backend: url::Url,
+    pub auth_provider: AuthProvider,
+}
+
+lazy_static::lazy_static! {
+    pub static ref AUTH_INFO_PROD: AuthProvider = {
+        let provider = "https://keycloak.omnect.conplement.cloud".to_string();
+        let realm = "cp-prod".to_string();
+        let client_id = "cp-production".to_string();
+        let bind_addr = "localhost:4000".to_string();
+        let redirect = url::Url::parse(&format!("http://{bind_addr}")).unwrap();
+
+        AuthProvider::Keycloak(
+            KeycloakInfo {
+            provider,
+            realm,
+            client_id,
+            bind_addr,
+            redirect,
+        })
+    };
+}

--- a/src/file/compression.rs
+++ b/src/file/compression.rs
@@ -136,7 +136,11 @@ pub fn decompress(image_file_name: &PathBuf, compression: &Compression) -> Resul
 }
 
 pub fn compress(image_file_name: &PathBuf, compression: &Compression) -> Result<PathBuf> {
-    let new_image_file = PathBuf::from(format!("{}.{}", image_file_name.to_str().unwrap(), compression.extension()));
+    let new_image_file = PathBuf::from(format!(
+        "{}.{}",
+        image_file_name.to_str().unwrap(),
+        compression.extension()
+    ));
     let mut destination = File::create(&new_image_file)?;
     let mut source = File::open(image_file_name)?;
     let bytes_written = compression.compress(&mut source, &mut destination)?;

--- a/src/file/compression.rs
+++ b/src/file/compression.rs
@@ -120,15 +120,19 @@ impl Compression {
 }
 
 pub fn decompress(image_file_name: &PathBuf, compression: &Compression) -> Result<PathBuf> {
-    let mut new_image_file = image_file_name.to_str().unwrap();
-    if let Some(p) = new_image_file.strip_suffix(compression.extension()) {
-        new_image_file = p;
+    let mut new_image_file = PathBuf::from(image_file_name);
+
+    if let Some(extension) = new_image_file.extension() {
+        if extension == compression.extension() {
+            new_image_file.set_extension("");
+        }
     }
-    let mut destination = File::create(new_image_file)?;
+
+    let mut destination = File::create(&new_image_file)?;
     let mut source = File::open(image_file_name)?;
     let bytes_written = compression.decompress(&mut source, &mut destination)?;
     debug!("image::decompress: copied {} bytes.", bytes_written);
-    Ok(PathBuf::from(new_image_file))
+    Ok(new_image_file)
 }
 
 pub fn compress(image_file_name: &PathBuf, compression: &Compression) -> Result<PathBuf> {

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -210,7 +210,7 @@ fn configure_hostname(
     let hosts_file = get_file_path(image_file.parent(), "hosts")?;
 
     // get hostname from identity_config_file
-    let identity: IdentityConfig = serde_path_to_error::deserialize(&mut toml::Deserializer::new(
+    let identity: IdentityConfig = serde_path_to_error::deserialize(toml::Deserializer::new(
         fs::read_to_string(identity_config_file.to_str().unwrap())
             .context("configure_hostname: cannot read identity file")?
             .as_str(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,6 @@ pub fn run() -> Result<()> {
             dir,
             priv_key_path,
             config_path,
-            backend,
             prod,
             dev,
         }) => {
@@ -183,7 +182,7 @@ pub fn run() -> Result<()> {
                 dir: Option<PathBuf>,
                 priv_key_path: Option<PathBuf>,
                 config_path: Option<PathBuf>,
-                backend: String,
+                backend: &str,
                 auth_info: &impl AuthInfo,
             ) -> Result<()> {
                 let access_token = crate::auth::authorize(auth_info)
@@ -197,10 +196,17 @@ pub fn run() -> Result<()> {
 
             assert!(prod ^ dev);
 
-            let auth_info = if prod {
-                &*crate::auth::AUTH_INFO_PROD,
+            // address of the backend API
+            let (backend, auth_info) = if prod {
+                (
+                    "https://cp.omnect.conplement.cloud",
+                    &*crate::auth::AUTH_INFO_PROD,
+                )
             } else if dev {
-                &*crate::auth::AUTH_INFO_DEV,
+                (
+                    "https://cp.dev.omnect.conplement.cloud",
+                    &*crate::auth::AUTH_INFO_DEV,
+                )
             } else {
                 unreachable!();
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub fn run() -> Result<()> {
                 config_path: Option<PathBuf>,
                 env_config: config::BackendConfig,
             ) -> Result<()> {
-                let access_token = crate::auth::authorize(env_config.auth_provider)
+                let access_token = crate::auth::authorize(env_config.auth)
                     .await
                     .context("create ssh tunnel")?;
 
@@ -200,7 +200,7 @@ pub fn run() -> Result<()> {
             } else {
                 config::BackendConfig {
                     backend: url::Url::parse("https://cp.omnect.conplement.cloud")?,
-                    auth_provider: config::AUTH_INFO_PROD.clone(),
+                    auth: config::AUTH_INFO_PROD.clone(),
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::process;
 
 fn main() {
     if cfg!(debug_assertions) {
-        Builder::from_env(Env::default().default_filter_or("debug,bollard::read=info")).init();
+        Builder::from_env(Env::default().default_filter_or("debug")).init();
     } else {
         Builder::from_env(Env::default().default_filter_or("info")).init();
     }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -27,20 +27,21 @@ pub struct Config {
 
 impl Config {
     pub fn new(
-        backend: String,
+        backend: impl AsRef<str>,
         dir: Option<PathBuf>,
         priv_key_path: Option<PathBuf>,
         config_path: Option<PathBuf>,
     ) -> Result<Config> {
-        let backend = match Url::parse(&backend) {
+        let backend = match Url::parse(backend.as_ref()) {
             Ok(url) => url,
             Err(url::ParseError::RelativeUrlWithoutBase) => {
                 // url has no scheme, attempt to fix it
-                Url::parse(&format!("https://{backend}"))
-                    .map_err(|_| anyhow::anyhow!("Invalid backend url: \"{backend}\"."))?
+                Url::parse(&format!("https://{}", backend.as_ref())).map_err(|_| {
+                    anyhow::anyhow!("Invalid backend url: \"{}\".", backend.as_ref())
+                })?
             }
             Err(_) => {
-                anyhow::bail!("Invalid backend url: \"{backend}\".")
+                anyhow::bail!("Invalid backend url: \"{}\".", backend.as_ref())
             }
         };
 

--- a/src/validators/device_update.rs
+++ b/src/validators/device_update.rs
@@ -11,6 +11,6 @@ pub fn validate_config(device_update_conf_file: &Path) -> Result<()> {
         .context("validate_du_config: read config_file")?;
 
     // ToDo: add further checks
-    
+
     Ok(())
 }

--- a/src/validators/identity.rs
+++ b/src/validators/identity.rs
@@ -188,7 +188,7 @@ pub fn validate_identity(
     let file_content = std::fs::read_to_string(config_file_name)
         .context("validate_identity: cannot read identity file")?;
     debug!("validate identity for:\n{}", file_content);
-    let des = &mut toml::Deserializer::new(&file_content);
+    let des = toml::Deserializer::new(&file_content);
     let body: Result<IdentityConfig, _> = serde_path_to_error::deserialize(des);
     let body = match body {
         Err(e) => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,7 @@ const TMPDIR_FORMAT_STR: &str = "/tmp/omnect-cli-integration-tests/";
 
 lazy_static! {
     static ref LOG: () = if cfg!(debug_assertions) {
-        Builder::from_env(Env::default().default_filter_or("debug,bollard::read=info")).init()
+        Builder::from_env(Env::default().default_filter_or("debug")).init()
     } else {
         Builder::from_env(Env::default().default_filter_or("info")).init()
     };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -733,8 +733,7 @@ async fn check_ssh_tunnel_setup() {
 
     let mock_access_token = oauth2::AccessToken::new("test_token_mock".to_string());
 
-    let mut config =
-        ssh::Config::new("test-backend".to_string(), Some(tr.pathbuf()), None, None).unwrap();
+    let mut config = ssh::Config::new("test-backend", Some(tr.pathbuf()), None, None).unwrap();
 
     let server = MockServer::start();
 


### PR DESCRIPTION
This adds a --prod and --dev switch to the ssh tunnel commands to connect to devices in prod or dev environments, respectively. Since this choice determines the used backend, this switch is dropped alltogether.

Furthermore, this fixes a naming issue when injecting files into images. This could lead to checksum issues with the resulting image/bmap file.