### PR TITLE
docker: fix and docu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.20.2] Q1 2024
 - omnect/omnect-cli docker image:
-  - optionally install additional tools for a cicd image: bash, readlink and sed
   - fixed `omnect-cli ssh set-certificate` command
   - documented `-b` option to create bmap file is not working
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.20.2] Q1 2024
-- fixed `omnect-cli ssh set-certificate` command in `omnect/omnect-cli:0.20.1` docker image
-- documented `-b` option to create bmap file is not working in `omnect/omnect-cli` docker image
+- omnect/omnect-cli docker image:
+  - fixed `omnect-cli ssh set-certificate` command
+  - documented `-b` option to create bmap file is not working
 
 ## [0.20.1] Q1 2024
 - added distroless docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.20.2] Q1 2024
 - omnect/omnect-cli docker image:
+  - added bash, readlink and sed
   - fixed `omnect-cli ssh set-certificate` command
   - documented `-b` option to create bmap file is not working
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.2] Q1 2024
+- fixed `omnect-cli ssh set-certificate` command in `omnect/omnect-cli:0.20.1` docker image
+- documented `-b` option to create bmap file is not working in `omnect/omnect-cli` docker image
+
 ## [0.20.1] Q1 2024
 - added distroless docker image
 - refactored partition handling of file functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.20.2] Q1 2024
 - omnect/omnect-cli docker image:
-  - added bash, readlink and sed
+  - optionally install additional tools for a cicd image: bash, readlink and sed
   - fixed `omnect-cli ssh set-certificate` command
   - documented `-b` option to create bmap file is not working
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.20.1"
+version = "0.20.2"
 
 [dependencies]
 actix-web = "4.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     libmagic1 \
     libssl3 \
     mtools \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+        && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     dpkg -i omnect-cli_${omnect_cli_version}_amd64.deb
 
 COPY --from=distroless /var/lib/dpkg/status.d /distroless_pkgs
@@ -34,6 +34,9 @@ RUN <<EOT
     mkdir -p /copy/status.d
 
     executables=( \
+        /bin/bash \
+        /bin/readlink \
+        /bin/sed \
         /usr/bin/dd \
         /usr/bin/e2cp \
         /usr/bin/e2mkdir \
@@ -86,6 +89,7 @@ EOT
 
 FROM ${distroless_image} AS base
 COPY --from=builder /usr/share/misc/magic.mgc /usr/share/misc/magic.mgc
+COPY --from=builder /copy/bin/ /bin/
 COPY --from=builder /copy/usr/bin/ /usr/bin/
 COPY --from=builder /copy/usr/sbin/ /usr/sbin/
 COPY --from=builder /copy/usr/lib/ /usr/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,10 @@ RUN apt-get update && \
     libmagic1 \
     libssl3 \
     mtools \
-        && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* && \
     dpkg -i omnect-cli_${omnect_cli_version}_amd64.deb
 
 COPY --from=distroless /var/lib/dpkg/status.d /distroless_pkgs
-
-ARG add_cicd_tools=false
 
 SHELL ["/bin/bash", "-c"]
 RUN <<EOT
@@ -46,15 +44,6 @@ RUN <<EOT
         /usr/bin/sync \
         /usr/sbin/fdisk \
     )
-
-    # add cicd tools
-    if [ "${add_cicd_tools}" == "true" ]; then
-        executables+=( \
-            /bin/bash \
-            /bin/readlink \
-            /bin/sed \
-        )
-    fi
 
     for executable in ${executables[@]}; do
         echo "${executable}"
@@ -97,7 +86,6 @@ EOT
 
 FROM ${distroless_image} AS base
 COPY --from=builder /usr/share/misc/magic.mgc /usr/share/misc/magic.mgc
-COPY --from=builder /copy/bi[n]/ /bin/
 COPY --from=builder /copy/usr/bin/ /usr/bin/
 COPY --from=builder /copy/usr/sbin/ /usr/sbin/
 COPY --from=builder /copy/usr/lib/ /usr/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ${debian_dir}/omnect-cli_${omnect_cli_version}_amd64.deb omnect-cli_${omnec
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-bmap-tools \
+    bmap-tools \
     ca-certificates \
     e2tools \
     fdisk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,16 +27,15 @@ RUN apt-get update && \
 
 COPY --from=distroless /var/lib/dpkg/status.d /distroless_pkgs
 
+ARG add_cicd_tools=false
+
 SHELL ["/bin/bash", "-c"]
 RUN <<EOT
     set -eu
 
     mkdir -p /copy/status.d
 
-    executables=( \
-        /bin/bash \
-        /bin/readlink \
-        /bin/sed \
+    executables=(
         /usr/bin/dd \
         /usr/bin/e2cp \
         /usr/bin/e2mkdir \
@@ -46,7 +45,16 @@ RUN <<EOT
         /usr/bin/ssh-keygen \
         /usr/bin/sync \
         /usr/sbin/fdisk \
-    ) 
+    )
+
+    # add cicd tools
+    if [ "${add_cicd_tools}" == "true" ]; then
+        executables+=( \
+            /bin/bash \
+            /bin/readlink \
+            /bin/sed \
+        )
+    fi
 
     for executable in ${executables[@]}; do
         echo "${executable}"
@@ -89,7 +97,7 @@ EOT
 
 FROM ${distroless_image} AS base
 COPY --from=builder /usr/share/misc/magic.mgc /usr/share/misc/magic.mgc
-COPY --from=builder /copy/bin/ /bin/
+COPY --from=builder /copy/bi[n]/ /bin/
 COPY --from=builder /copy/usr/bin/ /usr/bin/
 COPY --from=builder /copy/usr/sbin/ /usr/sbin/
 COPY --from=builder /copy/usr/lib/ /usr/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ${debian_dir}/omnect-cli_${omnect_cli_version}_amd64.deb omnect-cli_${omnec
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    bmap-tools \
+bmap-tools \
     ca-certificates \
     e2tools \
     fdisk \
@@ -34,14 +34,15 @@ RUN <<EOT
     mkdir -p /copy/status.d
 
     executables=( \
-        /usr/bin/omnect-cli \
-        /usr/sbin/fdisk \
         /usr/bin/dd \
-        /usr/bin/sync \
-        /usr/bin/e2mkdir \
         /usr/bin/e2cp \
+        /usr/bin/e2mkdir \
         /usr/bin/fallocate \
         /usr/bin/mcopy \
+        /usr/bin/omnect-cli \
+        /usr/bin/ssh-keygen \
+        /usr/bin/sync \
+        /usr/sbin/fdisk \
     ) 
 
     for executable in ${executables[@]}; do

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ docker run --rm -it \
   -v "$(pwd)":/source \
   -e RUST_LOG=debug \
   -u $(id -u) \
-  omnect/omnect-cli:0.20.1 file copy-to-image --files /source/my-source-file,boot:/my-dest-file -i /source/my-image.wic
+  omnect/omnect-cli:latest file copy-to-image --files /source/my-source-file,boot:/my-dest-file -i /source/my-image.wic
   ```
 
-  **Note**: `omnect-cli ssh set-connection`command is currently not supported by docker image.
+  **Note1**: `omnect-cli ssh set-connection`command is not supported by docker image.
+  **Note2**: `-b` option to create bmap file is not supported by docker image.
 
 # Build from sources
 

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,5 +1,5 @@
-# local buildversion
-cli_version="0.20.2"
+# local build
+cli_version=$(toml get --raw Cargo.toml package.version)
 rust_version="1.76.0-bookworm"
 
 docker build \

--- a/build-image.sh
+++ b/build-image.sh
@@ -7,6 +7,7 @@ docker build \
   --build-arg version_rust_container="${rust_version}" \
   --build-arg omnect_cli_version="${cli_version}" \
   --build-arg debian_dir=target/debian \
+  --build-arg add_cicd_tools=true \
   -f Dockerfile \
   --progress=plain \
   -t omnect-cli:"${cli_version}" .

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,9 +1,12 @@
-# local build
+# local buildversion
+cli_version="0.20.2"
+rust_version="1.76.0-bookworm"
+
 docker build \
   --build-arg docker_namespace=omnectweucopsacr.azurecr.io \
-  --build-arg version_rust_container=1.76.0-bookworm \
-  --build-arg omnect_cli_version=0.20.1 \
+  --build-arg version_rust_container="${rust_version}" \
+  --build-arg omnect_cli_version="${cli_version}" \
   --build-arg debian_dir=target/debian \
   -f Dockerfile \
   --progress=plain \
-  -t omnect-cli:0.20.1 .
+  -t omnect-cli:"${cli_version}" .

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ pub enum File {
         /// path to wic image file (optionally compressed with xz, bzip2 or gzip)
         #[arg(short = 'i', long = "image")]
         image: PathBuf,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]
@@ -55,7 +55,7 @@ pub enum IdentityConfig {
         /// path to wic image file (optionally compressed with xz, bzip2 or gzip)
         #[arg(short = 'i', long = "image")]
         image: PathBuf,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]
@@ -79,7 +79,7 @@ pub enum IdentityConfig {
         /// path to device identity certificate key file
         #[arg(short = 'k', long = "device_identity_key")]
         device_identity_key: PathBuf,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]
@@ -97,7 +97,7 @@ pub enum IdentityConfig {
         /// path to root ca certificate file
         #[arg(short = 'r', long = "root_ca")]
         root_ca: PathBuf,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]
@@ -121,7 +121,7 @@ pub enum IdentityConfig {
         /// period of validity in days
         #[arg(short = 'D', long = "days")]
         days: u32,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]
@@ -142,7 +142,7 @@ pub enum IotHubDeviceUpdate {
         /// path to wic image file (optionally compressed with xz, bzip2 or gzip)
         #[arg(short = 'i', long = "image")]
         image: PathBuf,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]
@@ -237,7 +237,7 @@ pub enum SshConfig {
         /// device-id
         #[arg(short = 'd', long = "device-principal")]
         device_principal: String,
-        /// optional: generate bmap file
+        /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,
         /// optional: pack image [xz, bzip2, gzip]

--- a/src/device_update.rs
+++ b/src/device_update.rs
@@ -265,9 +265,9 @@ pub async fn import_update(
         ],
     }];
 
-    let import_update = serde_json::to_string(&import_update).context("context")?;
+    let import_update = serde_json::to_string_pretty(&import_update).context("Cannot parse import_update")?;
 
-    debug!("{import_update}");
+    debug!("import update: {import_update}");
 
     let import_update_response = client.import_update(&instance_id, import_update).await?;
     info!("Result of import: {:?}", &import_update_response);


### PR DESCRIPTION
- fixed `omnect-cli ssh set-certificate` command in `omnect/omnect-cli:0.20.1` docker image
- documented `-b` option to create bmap file is not working in `omnect/omnect-cli` docker image
@empwilli @mlilien we need to refine how we can support bmap file generation in docker distroless. Either we implement our self or we copy all the python deps into distroless image. Are there other options?