### PR TITLE
feat(ssh): add ssh tunnel support for the docker image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.21.2"
+version = "0.22.0"
 
 [dependencies]
 actix-web = "4.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,6 @@ COPY --from=builder /copy/usr/lib/ /usr/lib/
 COPY --from=builder /copy/lib/ /lib/
 COPY --from=builder /copy/status.d /var/lib/dpkg/status.d
 
+ENV CONTAINERIZED="true"
+
 ENTRYPOINT [ "/usr/bin/omnect-cli" ]

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ for example, as follows:
 ```sh
 docker run --rm \
   -u 0:0 \
-  -v "~/.ssh":/root/.local/share/omnect-cli \
+  -v "C:/absolute/host/path/to/.ssh":/root/.local/share/omnect-cli \
   -v dev_env.toml:/dev_env.toml \
   -e CONTAINER_HOST=windows \
   -p 127.0.0.1:4000:4000 \

--- a/README.md
+++ b/README.md
@@ -226,15 +226,16 @@ necessary:
    `windows`.
 3. map the container's port on localhost 4000 to the hosts port 4000
 
-With our `prod_device` from above, the call would then look, for example, as follows:
+With our `dev_device` from above, the call would then look, for example, as follows:
 
 ```sh
 docker run --rm \
   -u 0:0 \
   -v "~/.ssh":/root/.local/share/omnect-cli \
+  -v dev_env.toml:/dev_env.toml \
   -p 127.0.0.1:4000:4000 \
   omnect/omnect-cli:latest \
-  ssh set-connection
+  ssh set-connection dev_device --env dev_env.toml
 ```
 
 If you want to use a custom backend configuration, you additionally have to

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run --rm -it \
   omnect/omnect-cli:latest file copy-to-image --files /source/my-source-file,boot:/my-dest-file -i /source/my-image.wic
   ```
 
-  **Note1**: `-b` option to create bmap file is not supported by docker image.
+  **Note1**: `-b` option to create bmap file is not supported by docker image.<br>
   **Note2**: The ssh tunnel option requires some additional settings. See [here](Usage-with-docker) for more details.
 
 # Build from sources

--- a/README.md
+++ b/README.md
@@ -226,13 +226,15 @@ necessary:
    `windows`.
 3. map the container's port on localhost 4000 to the hosts port 4000
 
-With our `dev_device` from above, the call would then look, for example, as follows:
+With our `dev_device` from above, the call on a Windows host would then look,
+for example, as follows:
 
 ```sh
 docker run --rm \
   -u 0:0 \
   -v "~/.ssh":/root/.local/share/omnect-cli \
   -v dev_env.toml:/dev_env.toml \
+  -e CONTAINER_HOST=windows \
   -p 127.0.0.1:4000:4000 \
   omnect/omnect-cli:latest \
   ssh set-connection dev_device --env dev_env.toml

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -175,7 +175,11 @@ pub async fn authorize<A>(auth_provider: A) -> Result<oauth2::AccessToken>
 where
     A: Into<AuthInfo>,
 {
-    let auth_info: AuthInfo = auth_provider.into();
+    let mut auth_info: AuthInfo = auth_provider.into();
+
+    if let Ok("true") | Ok("1") = std::env::var("CONTAINERIZED").as_deref() {
+        auth_info.bind_addr = "0.0.0.0:4000".to_string();
+    }
 
     // If there is a refresh token from previous runs, try to create our access
     // token from that. Note, that we don't store access tokens themselves as

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -217,7 +217,8 @@ Please remove config file first."#
     if let Ok("windows") = std::env::var("CONTAINER_HOST").as_deref() {
         writeln!(
             &mut writer,
-            r#"Host bastion
+            "\
+Host bastion
 	User {}
 	Hostname {}
 	Port {}
@@ -229,7 +230,7 @@ Host {}
 	User {}
 	IdentityFile ~/.ssh/{}
 	CertificateFile ~/.ssh/{}
-	ProxyCommand ssh bastion"#,
+	ProxyCommand ssh bastion",
             bastion_details.username,
             bastion_details.hostname,
             bastion_details.port,
@@ -254,7 +255,8 @@ Host {}
     } else {
         writeln!(
             &mut writer,
-            r#"Host bastion
+            "\
+Host bastion
 	User {}
 	Hostname {}
 	Port {}
@@ -266,7 +268,7 @@ Host {}
 	User {}
 	IdentityFile {}
 	CertificateFile {}
-	ProxyCommand ssh -F {} bastion"#,
+	ProxyCommand ssh -F {} bastion",
             bastion_details.username,
             bastion_details.hostname,
             bastion_details.port,

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -288,7 +288,7 @@ fn print_ssh_tunnel_info(cert_dir: &Path, config_path: &Path, destination: &str)
     println!("Successfully established ssh tunnel!");
     if let Ok("windows") = std::env::var("CONTAINER_HOST").as_deref() {
         println!(
-            "You can ssh to now ssh to your device via its device name, e.g.:\nssh {}",
+            "You can ssh now to your device via its device name, e.g.:\nssh {}",
             destination
         );
     } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -533,7 +533,7 @@ fn check_set_iot_hub_device_update_create_import_manifest() {
         std::fs::OpenOptions::new()
             .read(true)
             .create(false)
-            .open(&manifest_created)
+            .open(manifest_created)
             .unwrap(),
     )
     .unwrap();
@@ -544,7 +544,7 @@ fn check_set_iot_hub_device_update_create_import_manifest() {
         std::fs::OpenOptions::new()
             .read(true)
             .create(false)
-            .open(&manifest_original)
+            .open(manifest_original)
             .unwrap(),
     )
     .unwrap();


### PR DESCRIPTION
When running omnect-cli in a docker container, we need some extra steps to get the ssh tunnel feature to work. Furthermore, when running on windows host systems we have to make some adjustments in the ssh configuration. 

This PR extends the omnect-cli so that we can pass the setup (containerized or not, windows host) in via environment variables and to generate an according configuration. 

Furthermore, this extends the documentation to include the necessary steps to run the omnect-cli in a containerized environment.