### PR TITLE
feat(ssh): remove device-id argument from ssh set-certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.22.0"
+version = "0.23.0"
 
 [dependencies]
 actix-web = "4.4"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ omnect-cli is a command-line tool to manage omnect-os empowered devices. It prov
   - copy files to image in order to configure e.g. boot service, firewall, wifi and others
   - copy files from image, e.g. to patch and re-inject configurations
 - ssh:
-  - inject a ssh root ca and device principal for ssh tunnel creation
+  - inject a ssh root ca for ssh tunnel creation
 
 Further omnect-cli supports device management features. Currently supported:
   - open a ssh tunnel on a device in the field to connect to it
@@ -151,7 +151,7 @@ omnect-cli file copy-to-image --help
 
 ### Inject ssh tunnel credentials
 
-For the ssh feature, the device requires the public key of the ssh root ca and the principal. The latter should be the device id.
+For the ssh feature, the device requires the public key of the ssh root ca.
 
 Detailed description:
 ```sh

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -261,9 +261,6 @@ pub enum SshConfig {
         /// path to public key of the ssh root ca
         #[arg(short = 'r', long = "root_ca")]
         root_ca: PathBuf,
-        /// device-id
-        #[arg(short = 'd', long = "device-principal")]
-        device_principal: String,
         /// optional: generate bmap file (currently not working in docker image)
         #[arg(short = 'b', long = "generate-bmap-file")]
         generate_bmap: bool,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -76,24 +76,15 @@ pub fn set_iot_leaf_sas_config(
     copy_to_image(&file_copies, image_file)
 }
 
-pub fn set_ssh_tunnel_certificate(
-    image_file: &Path,
-    root_ca_file: &Path,
-    device_principal: &str,
-) -> Result<()> {
+pub fn set_ssh_tunnel_certificate(image_file: &Path, root_ca_file: &Path) -> Result<()> {
     validate_ssh_pub_key(root_ca_file)?;
-    let authorized_principals_file = get_file_path(image_file.parent(), "authorized_principals")?;
-    fs::write(&authorized_principals_file, device_principal)?;
 
     copy_to_image(
-        &[
-            FileCopyToParams::new(root_ca_file, Partition::cert, Path::new("/ssh/root_ca")),
-            FileCopyToParams::new(
-                &authorized_principals_file.to_path_buf(),
-                Partition::cert,
-                Path::new("/ssh/authorized_principals"),
-            ),
-        ],
+        &[FileCopyToParams::new(
+            root_ca_file,
+            Partition::cert,
+            Path::new("/ssh/root_ca"),
+        )],
         image_file,
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,11 +167,10 @@ pub fn run() -> Result<()> {
         Command::Ssh(SetCertificate {
             image,
             root_ca,
-            device_principal,
             generate_bmap,
             compress_image,
         }) => run_image_command(image, generate_bmap, compress_image, |img: &PathBuf| {
-            file::set_ssh_tunnel_certificate(img, &root_ca, &device_principal)
+            file::set_ssh_tunnel_certificate(img, &root_ca)
         })?,
         Command::IotHubDeviceUpdate(IotHubDeviceUpdateSet {
             iot_hub_device_update_config,


### PR DESCRIPTION
With newer versions of the omnect-device-service we don't need to inject the device principal any longer. Hence, we remove this argument.