### PR TITLE
fix: copy-from-image: prevent "Invalid cross-device link" errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.23.2"
+version = "0.23.3"
 
 [dependencies]
 actix-web = "4.4"

--- a/src/file/functions.rs
+++ b/src/file/functions.rs
@@ -281,7 +281,7 @@ pub fn copy_from_image(file_copy_params: &[FileCopyFromParams], image_file: &Pat
 
     for param in file_copy_params.iter() {
         let mut partition_file = working_dir.clone();
-        let mut tmp_out_file = working_dir.clone();
+
         let partition_info = get_partition_info(image_file, &param.partition)?;
         let in_file = param.in_file.to_str().unwrap();
 
@@ -289,14 +289,27 @@ pub fn copy_from_image(file_copy_params: &[FileCopyFromParams], image_file: &Pat
         let partition_file = partition_file.to_str().unwrap();
 
         read_partition(image_file, partition_file, &partition_info)?;
-        tmp_out_file.push(format!(
-            "{}-{}",
-            Uuid::new_v4(),
-            param.out_file.file_name().unwrap().to_str().unwrap()
-        ));
 
-        // 1. copy to working_dir
+        anyhow::ensure!(
+            param
+                .out_file
+                .parent()
+                .unwrap()
+                .try_exists()
+                .is_ok_and(|exists| exists),
+            "copy_from_image: output dir does not exist."
+        );
+
+        // copy
         if param.partition == Partition::boot {
+            let mut tmp_out_file = working_dir.clone();
+            // mcopy deadlocks when target file is not residing in workingdir so we copy to a temp file
+            tmp_out_file.push(format!(
+                "{}-{}",
+                Uuid::new_v4(),
+                param.out_file.file_name().unwrap().to_str().unwrap()
+            ));
+
             let mut mcopy = Command::new("mcopy");
             mcopy
                 .arg("-o")
@@ -305,40 +318,31 @@ pub fn copy_from_image(file_copy_params: &[FileCopyFromParams], image_file: &Pat
                 .arg(format!("::{in_file}"))
                 .arg(&tmp_out_file);
             exec_cmd!(mcopy);
+            // instead of rename we copy and delete to prevent "Invalid cross-device link" errors
+            let bytes_copied = fs::copy(&tmp_out_file, &param.out_file).context(format!(
+                "copy_from_image: couldn't copy temp file {} to destination {}",
+                tmp_out_file.to_str().unwrap(),
+                param.out_file.to_str().unwrap()
+            ))?;
+            anyhow::ensure!(
+                tmp_out_file.metadata().unwrap().len() == bytes_copied,
+                "copy_from_image: copy temp file failed"
+            );
+            fs::remove_file(&tmp_out_file).context(format!(
+                "copy_from_image: couldn't delete temp file {}",
+                tmp_out_file.to_str().unwrap()
+            ))?;
         } else {
             let mut e2cp = Command::new("e2cp");
             e2cp.arg(format!("{partition_file}:{in_file}"))
-                .arg(tmp_out_file.to_str().unwrap());
+                .arg(param.out_file.to_str().unwrap());
             exec_cmd!(e2cp);
             // since e2cp doesn't return errors in any case we check if output file exists
             anyhow::ensure!(
-                tmp_out_file.try_exists().is_ok_and(|exists| exists),
+                param.out_file.try_exists().is_ok_and(|exists| exists),
                 format!("copy_from_image: cmd failed: {:?}", e2cp)
             )
         }
-
-        // 2.create final dir and move tmp file into
-        if let Some(parent) = param.out_file.parent() {
-            fs::create_dir_all(parent).context(format!(
-                "copy_from_image: couldn't create destination path {}",
-                parent.to_str().unwrap()
-            ))?;
-        }
-
-        // instead of rename we copy and delete to prevent "Invalid cross-device link" errors
-        let bytes_copied = fs::copy(&tmp_out_file, &param.out_file).context(format!(
-            "copy_from_image: couldn't copy temp file {} to destination {}",
-            tmp_out_file.to_str().unwrap(),
-            param.out_file.to_str().unwrap()
-        ))?;
-        anyhow::ensure!(
-            tmp_out_file.metadata().unwrap().len() == bytes_copied,
-            "copy_from_image: copy temp file failed"
-        );
-        fs::remove_file(&tmp_out_file).context(format!(
-            "copy_from_image: couldn't delete temp file {}",
-            tmp_out_file.to_str().unwrap()
-        ))?;
     }
 
     Ok(())

--- a/src/file/functions.rs
+++ b/src/file/functions.rs
@@ -294,10 +294,6 @@ pub fn copy_from_image(file_copy_params: &[FileCopyFromParams], image_file: &Pat
             Uuid::new_v4(),
             param.out_file.file_name().unwrap().to_str().unwrap()
         ));
-        anyhow::ensure!(
-            tmp_out_file != param.out_file,
-            "copy_to_image: temp file is same as out_file"
-        );
 
         // 1. copy to working_dir
         if param.partition == Partition::boot {

--- a/src/file/functions.rs
+++ b/src/file/functions.rs
@@ -323,10 +323,15 @@ pub fn copy_from_image(file_copy_params: &[FileCopyFromParams], image_file: &Pat
                 parent.to_str().unwrap()
             ))?;
         }
-        fs::rename(&tmp_out_file, &param.out_file).context(format!(
-            "copy_from_image: couldn't move temp file {} to destination {}",
+        // instead of rename we copy and delete to prevent "Invalid cross-device link" errors
+        fs::copy(&tmp_out_file, &param.out_file).context(format!(
+            "copy_from_image: couldn't copy temp file {} to destination {}",
             tmp_out_file.to_str().unwrap(),
             param.out_file.to_str().unwrap()
+        ))?;
+        fs::remove_file(&tmp_out_file).context(format!(
+            "copy_from_image: couldn't delete temp file {}",
+            tmp_out_file.to_str().unwrap()
         ))?;
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,7 +4,7 @@ use assert_json_diff::assert_json_eq;
 use common::Testrunner;
 use httpmock::prelude::*;
 use omnect_cli::ssh;
-use std::path::PathBuf;
+use std::{fs::create_dir_all, path::PathBuf};
 use stdext::function_name;
 
 #[macro_use]
@@ -38,6 +38,7 @@ fn check_set_identity_gateway_config() {
 
     let mut config_file_out_path = tr.pathbuf();
     config_file_out_path.push("dir1");
+    create_dir_all(config_file_out_path.clone()).unwrap();
     let mut root_ca_file_out_path = config_file_out_path.clone();
     let mut edge_device_identity_full_chain_file_out_path = config_file_out_path.clone();
     let mut edge_device_identity_key_file_out_path = config_file_out_path.clone();
@@ -145,6 +146,7 @@ fn check_set_identity_leaf_config() {
 
     let mut config_file_out_path = tr.pathbuf();
     config_file_out_path.push("dir1");
+    create_dir_all(config_file_out_path.clone()).unwrap();
     let mut root_ca_file_out_path = config_file_out_path.clone();
     let mut hosts_file_out_path = config_file_out_path.clone();
     let mut hostname_file_out_path = config_file_out_path.clone();
@@ -215,6 +217,7 @@ fn check_set_identity_config_est_template() {
 
     let mut config_file_out_path = tr.pathbuf();
     config_file_out_path.push("dir1");
+    create_dir_all(config_file_out_path.clone()).unwrap();
     let mut hosts_file_out_path = config_file_out_path.clone();
     let mut hostname_file_out_path = config_file_out_path.clone();
 
@@ -279,6 +282,7 @@ fn check_set_identity_config_payload_template() {
 
     let mut config_file_out_path = tr.pathbuf();
     config_file_out_path.push("dir1");
+    create_dir_all(config_file_out_path.clone()).unwrap();
     let mut payload_out_path = config_file_out_path.clone();
     let mut hosts_file_out_path = config_file_out_path.clone();
     let mut hostname_file_out_path = config_file_out_path.clone();
@@ -351,6 +355,7 @@ fn check_set_identity_config_tpm_template() {
 
     let mut config_file_out_path = tr.pathbuf();
     config_file_out_path.push("dir1");
+    create_dir_all(config_file_out_path.clone()).unwrap();
     let mut hosts_file_out_path = config_file_out_path.clone();
     let mut hostname_file_out_path = config_file_out_path.clone();
 
@@ -418,6 +423,8 @@ fn check_set_device_cert() {
 
     let mut device_id_cert_out_path = tr.pathbuf();
     device_id_cert_out_path.push("dir1");
+    create_dir_all(device_id_cert_out_path.clone()).unwrap();
+
     let mut device_id_cert_key_out_path = device_id_cert_out_path.clone();
     let mut ca_crt_pem_out_path = device_id_cert_out_path.clone();
     let mut ca_pem_out_path = device_id_cert_out_path.clone();
@@ -481,6 +488,7 @@ fn check_set_iot_hub_device_update_template() {
 
     let mut adu_config_file_out_path = tr.pathbuf();
     adu_config_file_out_path.push("dir1");
+    create_dir_all(adu_config_file_out_path.clone()).unwrap();
     adu_config_file_out_path.push("adu_config_file_out_path");
     let adu_config_file_out_path = adu_config_file_out_path.to_str().unwrap();
 
@@ -572,12 +580,18 @@ fn check_file_copy(tr: Testrunner, partition: &str) {
     let in_file1 = in_file1.to_str().unwrap();
     let in_file2 = tr.to_pathbuf("testfiles/dps-payload.json");
     let in_file2 = in_file2.to_str().unwrap();
-    let out_file1 = "/test/test1.scr";
-    let out_file2 = "/test2.json";
+    let mut out_file1 = tr.pathbuf();
+    out_file1.push("test/test1.scr");
+    create_dir_all(out_file1.parent().unwrap()).unwrap();
+    let out_file1 = out_file1.to_str().unwrap();
+    let mut out_file2 = tr.pathbuf();
+    out_file2.push("test2.json");
+    let out_file2 = out_file2.to_str().unwrap();
     let image_path = tr.to_pathbuf("testfiles/image.wic");
     let mut out_file3 = tr.pathbuf();
     out_file3.push("dir1");
     out_file3.push("outfile3.scr");
+    create_dir_all(out_file3.parent().unwrap()).unwrap();
     let out_file3 = out_file3.to_str().unwrap();
     let mut out_file4 = tr.pathbuf();
     out_file4.push("outfile4.json");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -110,6 +110,9 @@ fn check_set_identity_gateway_config() {
         edge_device_identity_key_file_path.to_str().unwrap(),
         edge_device_identity_key_file_out_path
     ));
+    assert!(std::path::Path::new(hosts_file_out_path)
+        .try_exists()
+        .is_ok_and(|exists| exists));
 
     assert!(std::fs::read_to_string(hosts_file_out_path)
         .unwrap()


### PR DESCRIPTION
copy-from-image: 
- don't create output dir
- don't copy to temporary file when using `e2cp`
- ensure temporary file is not equal to out_file when using `mcopy` (`mcopy` needs temporary file handling, when out_file is not residing in workdir otherwise `mcopy` deadlocks)