### PR TITLE
feat(ssh_tunnel): add support for authentication via ipv4 and ipv6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.24.0"
+version = "0.24.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.24.0"
+version = "0.24.2"
 
 [dependencies]
 actix-web = "4.4"

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ backend = 'https://cp.dev.omnect.conplement.cloud'
 provider = 'https://keycloak.omnect.conplement.cloud'
 realm = 'cp-dev'
 client_id = 'cp-cli'
-bind_addr = 'localhost:4000'
+bind_addrs = ['127.0.0.1:4000', '[::1]:4000']
 redirect = 'http://localhost:4000'
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ pub struct KeycloakInfo {
     provider: String,
     realm: String,
     client_id: String,
-    bind_addr: String,
+    bind_addrs: Vec<String>,
     redirect: url::Url,
 }
 
@@ -22,7 +22,7 @@ impl From<KeycloakInfo> for AuthInfo {
                 "{}/realms/{}/protocol/openid-connect/token",
                 val.provider, val.realm
             ),
-            bind_addr: val.bind_addr,
+            bind_addrs: val.bind_addrs,
             redirect_addr: val.redirect,
             client_id: val.client_id,
         }
@@ -53,15 +53,15 @@ lazy_static::lazy_static! {
         let provider = "https://keycloak.omnect.conplement.cloud".to_string();
         let realm = "cp-prod".to_string();
         let client_id = "cp-cli".to_string();
-        let bind_addr = "localhost:4000".to_string();
-        let redirect = url::Url::parse(&format!("http://{bind_addr}")).unwrap();
+        let bind_addrs = vec!["127.0.0.1:4000".to_string(), "[::1]:4000".to_string()];
+        let redirect = url::Url::parse("http://localhost:4000").unwrap();
 
         AuthProvider::Keycloak(
             KeycloakInfo {
             provider,
             realm,
             client_id,
-            bind_addr,
+            bind_addrs,
             redirect,
         })
     };


### PR DESCRIPTION
Some users of the situation faced the situation where redirect link the oauth2 flow was not invoked correctly. The problem here was that localhost was resolved differently, depending on the respective user's machine (either as IPv4 only or as IPv6 only). If the redirect server, however, bound to the opposing protocol, the resolver link did not work.

To the best of our knowledge, this is an issue with actix (or underlying crates), as the "bind" method promises to bind to either IPv4 and IPv6 if "localhost" is specified.

With this fix we resolve the issue by extending the authentication info so that multiple bind addresses can be specified. We then explicitly specify both, the IPv4 and the IPv6 localhost addresses.