### PR TITLE
docs(ssh_tunnel): fix config path for docker setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.24.5"
+version = "0.24.6"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.24.5"
+version = "0.24.6"
 
 [dependencies]
 actix-web = "4.4"

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ for example, as follows:
 ```sh
 docker run --rm \
   -u 0:0 \
-  -v "C:/absolute/host/path/to/.ssh":/root/.local/share/omnect-cli \
+  -v "C:/absolute/host/path/to/.ssh":/root/.config/omnect-cli \
   -v dev_env.toml:/dev_env.toml \
   -e CONTAINER_HOST=windows \
   -p 127.0.0.1:4000:4000 \


### PR DESCRIPTION
We changed the base directory for generated ssh configuration files to be consistent in the code base. With this change, the path of the configuration file in the docker example changed, as well. The documentation currently still shows an example with the old path, thus causing the example to not work. We update the example so that it is functional again.