### PR TITLE
fix(cli): enable clap help and usage features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-cli"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1692,6 +1707,7 @@ dependencies = [
  "oauth2",
  "omnect-crypto",
  "open",
+ "predicates",
  "regex",
  "reqwest 0.13.2",
  "ring",
@@ -1897,7 +1913,10 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-cli"
 readme = "README.md"
 repository = "https://github.com/omnect/omnect-cli"
-version = "0.28.0"
+version = "0.28.1"
 
 [dependencies]
 actix-web = "4.11"
@@ -16,7 +16,9 @@ base64 = { version = "0.22", default-features = false }
 bzip2 = { version = "0.6", default-features = true }
 clap = { version = "4.5", default-features = false, features = [
     "derive",
+    "help",
     "std",
+    "usage",
 ] }
 directories = { version = "6.0", default-features = false }
 env_logger = { version = "0.11", default-features = false }
@@ -73,6 +75,7 @@ assert-json-diff = "2.0"
 data-encoding = "2.9"
 file_diff = "1.0"
 httpmock = "0.8"
+predicates = "3.1"
 ring = "0.17"
 tar = "0.4"
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,8 +4,68 @@ use assert_json_diff::assert_json_eq;
 use common::Testrunner;
 use httpmock::prelude::*;
 use omnect_cli::ssh;
+use predicates::prelude::*;
 use std::{fs::create_dir_all, path::PathBuf};
 use stdext::function_name;
+
+#[test]
+fn check_help_root_level() {
+    Command::cargo_bin("omnect-cli")
+        .expect("binary exists")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("docker"))
+        .stdout(predicate::str::contains("identity"))
+        .stdout(predicate::str::contains("ssh"));
+}
+
+#[test]
+fn check_help_subcommand_group() {
+    Command::cargo_bin("omnect-cli")
+        .expect("binary exists")
+        .arg("identity")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("set-config"))
+        .stdout(predicate::str::contains("set-device-certificate"));
+}
+
+#[test]
+fn check_help_leaf_command() {
+    Command::cargo_bin("omnect-cli")
+        .expect("binary exists")
+        .arg("identity")
+        .arg("set-config")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--image"));
+}
+
+#[test]
+fn check_help_short_flag() {
+    Command::cargo_bin("omnect-cli")
+        .expect("binary exists")
+        .arg("identity")
+        .arg("set-config")
+        .arg("-h")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--config"));
+}
+
+#[test]
+fn check_version_flag() {
+    Command::cargo_bin("omnect-cli")
+        .expect("binary exists")
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("omnect-cli"));
+}
 
 #[test]
 fn check_set_identity_gateway_config() {


### PR DESCRIPTION
## Summary
- clap was configured with `default-features = false` and only `["derive", "std"]`, which excluded the `help` feature — causing `--help`/`-h` to fail with `error: unexpected argument found` at every subcommand level
- Added `"help"` and `"usage"` clap features to restore flag support and usage synopsis
- Added 5 regression tests covering `--help` at root, subcommand group, and leaf levels, plus `-h` short form and `--version`
